### PR TITLE
Support <a href="..." rel="next"> links

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+indent_style = tab


### PR DESCRIPTION
It's becoming more common for webcomics (such as https://www.smbc-comics.com/) to use CSS to display a 'next' image, leaving a nav block that looks like this:

```
<a href="https://www.smbc-comics.com/comic/2002-09-05" class="first" rel="start"></a>
<a href="https://www.smbc-comics.com/comic/survival" class="prev" rel="prev"></a>
<a href="https://www.smbc-comics.com/random.php" class="navaux" rel="rss"></a>
<a href="https://www.smbc-comics.com/comic/wise-master" class="next" rel="next"></a>
<a href="https://www.smbc-comics.com/comic/wise-master" class="last" rel="index"></a>
```

This PR adds support for the `rel="next"` attribute, allowing PageZipper to see and use these links.