### PR TITLE
"p" synonym

### DIFF
--- a/src/pagezipper.js
+++ b/src/pagezipper.js
@@ -13,6 +13,7 @@ function PageZipper() {
 							{syn: ">>", weight: 30, humanReadableOnly: true},
 							{syn: "more", weight: 20},
 							{syn: "page", weight: 10},
+							{syn: "p", weight: 8},
 							{syn: "part", weight: 5},
 							{syn: "-1", weight: 0, humanReadableOnly: true, pageBar: true}		//for nav bars that list pages 1234, list the next page
 						];


### PR DESCRIPTION
Makes the extension work, for example, on https://allegro.pl/ .